### PR TITLE
feat(transcode): 다중 해상도 HLS 및 master.m3u8 동적 생성

### DIFF
--- a/src/services/transcode_service.py
+++ b/src/services/transcode_service.py
@@ -59,7 +59,6 @@ def transcode_video(filename: str) -> dict:
     os.makedirs(os.path.join(output_dir, "480p"), exist_ok=True)
     os.makedirs(os.path.join(output_dir, "1080p"), exist_ok=True)
 
-    # send_status(video_id, "in_progress", 0)
     publish_progress(video_id, "in_progress", 0)
 
     try:
@@ -102,7 +101,6 @@ def transcode_video(filename: str) -> dict:
                 progress = int(min(seconds / duration * 100, 100))
                 # 진행 상황에 변동이 있을 때만 전송
                 if progress > last_progress:
-                    # send_status(video_id, "in_progress", progress)
                     publish_progress(video_id, "in_progress", progress)
                     last_progress = progress
 
@@ -136,7 +134,6 @@ def transcode_video(filename: str) -> dict:
                 logger.debug(f"📤 Uploaded segment: {s3_key}")
 
         logger.info(f"[Logic] ✅ Transcoding complete: s3://{BUCKET_NAME}/{s3_prefix}master.m3u8")
-        # send_status(video_id, "success", 100)
         publish_progress(video_id, "success", 100)
 
         success = True
@@ -151,7 +148,6 @@ def transcode_video(filename: str) -> dict:
     except Exception as e:
         if not locals().get("success"):
             logger.exception(f"[Logic] ❌ Transcoding failed: {e}")
-            # send_status(video_id, "failed", 0)
             publish_progress(video_id, "failed", 0)
         raise e
 

--- a/src/services/transcode_service.py
+++ b/src/services/transcode_service.py
@@ -116,7 +116,7 @@ def transcode_video(filename: str) -> dict:
         if process.returncode != 0:
             raise subprocess.CalledProcessError(process.returncode, ffmpeg_cmd)
 
-        logger.info("🎞️ FFmpeg to HLS conversion complete")
+        logger.info("🎞️  FFmpeg to HLS conversion complete")
 
         renditions = {
             "480p": {

--- a/src/services/transcode_service.py
+++ b/src/services/transcode_service.py
@@ -45,7 +45,7 @@ def transcode_video(filename: str) -> dict:
         filename (str): S3의 원본 영상 경로 (예: original/1234-abc.mp4)
 
     Returns:
-        dict: 트랜스코딩 완료 정보 (videoId, m3u8 위치, 상태, 진행률)
+        void
     """
 
     logger.info(f"[Logic] Starting transcoding: {filename}")

--- a/src/services/transcode_service.py
+++ b/src/services/transcode_service.py
@@ -2,6 +2,7 @@ import subprocess
 import shutil
 import os
 import re
+import textwrap
 
 from src.core.s3 import s3, BUCKET_NAME
 from src.utils.logging_utils import setup_logger
@@ -110,13 +111,13 @@ def transcode_video(filename: str) -> dict:
 
         logger.info("🎞️ FFmpeg to HLS conversion complete")
 
-
-        master_m3u8 = """#EXTM3U
-        #EXT-X-STREAM-INF:BANDWIDTH=1400000,RESOLUTION=854x480
-        480p/output.m3u8
-        #EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080
-        1080p/output.m3u8
-        """
+        master_m3u8 = textwrap.dedent("""\
+            #EXTM3U
+            #EXT-X-STREAM-INF:BANDWIDTH=1400000,RESOLUTION=854x480
+            480p/output.m3u8
+            #EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080
+            1080p/output.m3u8
+        """)
 
         with open(os.path.join(output_dir, "master.m3u8"), "w") as f:
             f.write(master_m3u8)

--- a/src/services/transcode_service.py
+++ b/src/services/transcode_service.py
@@ -149,12 +149,12 @@ def transcode_video(filename: str) -> dict:
 
         success = True
 
-        # return {
-        #     "videoId": video_id,
-        #     "m3u8": f"{s3_prefix}master.m3u8",
-        #     "status": "success",
-        #     "progress": 100
-        # }
+        return {
+            "videoId": video_id,
+            "m3u8": f"{s3_prefix}master.m3u8",
+            "status": "success",
+            "progress": 100
+        }
 
     except Exception as e:
         if not locals().get("success"):

--- a/src/services/transcode_service.py
+++ b/src/services/transcode_service.py
@@ -111,15 +111,25 @@ def transcode_video(filename: str) -> dict:
 
         logger.info("🎞️ FFmpeg to HLS conversion complete")
 
-        master_m3u8 = textwrap.dedent("""\
-            #EXTM3U
-            #EXT-X-STREAM-INF:BANDWIDTH=1400000,RESOLUTION=854x480
-            480p/output.m3u8
-            #EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080
-            1080p/output.m3u8
-        """)
+        renditions = {
+            "480p": {
+                "bandwidth": 1400000,
+                "resolution": "854x480"
+            },
+            "1080p": {
+                "bandwidth": 5000000,
+                "resolution": "1920x1080"
+            },
+        }
 
-        with open(os.path.join(output_dir, "master.m3u8"), "w") as f:
+        lines = ["#EXTM3U"]
+        for label, props in renditions.items():
+            lines.append(f"#EXT-X-STREAM-INF:BANDWIDTH={props['bandwidth']},RESOLUTION={props['resolution']}")
+            lines.append(f"{label}/output.m3u8")
+
+        master_m3u8 = "\n".join(lines)
+
+        with open(os.path.join(output_dir, "master.m3u8"), "w", encoding="utf-8", newline="\n") as f:
             f.write(master_m3u8)
 
 

--- a/src/tasks/transcode_video_task.py
+++ b/src/tasks/transcode_video_task.py
@@ -8,4 +8,4 @@ logger = setup_logger(__name__)
 @celery_app.task(name="transcode_video_task")
 def transcode_video_task(filename: str):
     logger.info(f"[Task] Task received for filename: {filename}")
-    transcode_video(filename)
+    return transcode_video(filename)

--- a/src/tests/send_transcode_request.py
+++ b/src/tests/send_transcode_request.py
@@ -7,7 +7,8 @@ logger = setup_logger(__name__)
 
 def main():
     file_type = "video"
-    filename = "1748193451965-cap-flow.mp4"
+    # filename = "1748191347517-cap-ucc.mp4"
+    filename = "wak.mp4"
 
     payload = {
         "file_type": file_type,


### PR DESCRIPTION
## 📌 관련 이슈
* Resolves #1 

___

## ✨ 작업 내용

- FFmpeg를 활용해 HLS 다중 해상도(480p, 1080p) 트랜스코딩 지원
- master.m3u8 플레이리스트 동적 생성 로직 추가
- 파일 인코딩 및 줄바꿈 형식 명시 (`UTF-8`, `LF`)

___

## 🔎 세부 설명

- `transcode_service.py` 내부에서 해상도별 output 디렉토리 생성 후 각각 FFmpeg 명령으로 트랜스코딩 수행
- `renditions` dict를 활용해 확장성 있는 해상도 목록 관리
- `master.m3u8` 생성 시 `encoding="utf-8"`, `newline="\n"`을 명시하여 플레이어 호환성 확보
- `hexdump`, `file -I` 명령을 통해 인코딩 및 줄바꿈 정상 확인
- `send_status()`는 일시 제거하고 `publish_progress()`만 사용 (간소화 목적)

___

## 🧪 테스트

- [x] 480p / 1080p 트랜스코딩 성공 여부 확인
- [x] master.m3u8 파일 생성 및 S3 업로드 확인
- [x] ffprobe/ffmpeg 없는 경우 fallback 동작 확인

___

## 📁 변경된 파일/폴더

- `src/services/transcode_service.py` → 다중 해상도 트랜스코딩 및 master.m3u8 생성 로직 추가
- 신규 파일 생성: 각 해상도 폴더 내 HLS 세그먼트 + master.m3u8

___

## ➕ 기타

- 이후 해상도 옵션은 환경변수 혹은 설정파일 기반으로 분리 예정
- `master.m3u8` 메타데이터 개선 여지 있음 (codecs, audio group 등)