### PR TITLE
[S3/FEAT] Limit concurrency to 1 to ensure single active worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       dockerfile: Dockerfile
     container_name: cms-transcode-worker
     working_dir: /
-    command: celery -A src.worker.celery_worker.celery_app worker --loglevel=info
+    command: celery -A src.worker.celery_worker.celery_app worker --loglevel=info --concurrency=1
     volumes:
       - ./src:/src
     environment:


### PR DESCRIPTION
## 📌 관련 이슈
- Resolves #5 

___

## ✨ 작업 내용
- [BE] Celery Worker의 Concurrency를 1로 제한

___

## 🔎 세부 설명
- Celery Worker의 활성화된 동시 작업자 수(concurrency)를 1로 설정하여, 트랜스코딩 중복 실행이나 리소스 충돌 문제를 방지했습니다.
- `docker-compose.yml`의 worker 명령어를 수정하여 `--concurrency=1` 플래그를 명시했습니다.

___

## 🧪 테스트
- [x] 로컬 Docker Compose로 Celery Worker 실행 시, 단일 워커만 활성화됨을 로그로 확인
- [x] Redis/RabbitMQ 메시지 처리 정상 동작 확인
- [x] 트랜스코딩 진행 중 다른 요청이 대기 상태로 전환되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Celery 워커 서비스의 동시 실행 수를 1로 제한하도록 docker-compose 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->